### PR TITLE
Dependency hash generating and binary_dep generating  is relocated to…

### DIFF
--- a/rocksolver-0.5.rockspec
+++ b/rocksolver-0.5.rockspec
@@ -1,11 +1,11 @@
 -- This file was automatically generated for the LuaDist project.
 
 package = "rocksolver"
-version = "0.4.2-4"
+version = "0.5"
 -- LuaDist source
 source = {
   url = "git://github.com/LuaDist-core/rocksolver.git",
-  tag = "0.4.2-4"
+  tag = "0.5"
 }
 -- Original source
 -- source = {
@@ -18,7 +18,8 @@ description = {
     license = "MIT"
 }
 dependencies = {
-    "lua >= 5.1"
+    "lua >= 5.1",
+    "md5 >= 1.2-1",
 }
 build = {
     type = "builtin",

--- a/rocksolver/DependencySolver.lua
+++ b/rocksolver/DependencySolver.lua
@@ -6,8 +6,6 @@
 local const = require("rocksolver.constraints")
 local utils = require("rocksolver.utils")
 local Package = require("rocksolver.Package")
-local mgr = require "dist.manager"
-
 
 local DependencySolver = {}
 DependencySolver.__index = DependencySolver
@@ -142,7 +140,7 @@ function DependencySolver:resolve_dependencies(package, installed, dependency_pa
                 local bin_candidate = tmp_installed[#tmp_installed]
 
                 -- Generate hash from dependencies of binary candidate
-                local required_pkg_hash = mgr.generate_dep_hash(bin_candidate:dependencies(self.platform), tmp_installed)
+                local required_pkg_hash = utils.generate_dep_hash(self.platform, bin_candidate:dependencies(self.platform), tmp_installed)
 
                 -- If candidate contains hash (is binary package), but was built with other dependencies or on other platform
                 if bin_candidate.version.hash ~= required_pkg_hash then


### PR DESCRIPTION
… rocksolver, add md5 dependency, modify tests

Tests were modified,so user is able to test multiple manifests.